### PR TITLE
Add post-id-xx or page-id-xx class to TinyMCE previews

### DIFF
--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -95,6 +95,33 @@ function trestle_admin_actions() {
 
 }
 
+add_filter( 'tiny_mce_before_init', 'trestle_tiny_mce_before_init' );
+/**
+ * Add custom classes to the body of TinyMCE previews.
+ *
+ * @since  2.1.0
+ */
+function trestle_tiny_mce_before_init( $init_array ) {
+
+	global $post;
+
+	$screen = get_current_screen();
+
+	// If we're on an edit screen, add an appropriate 'post-id-XX' or 'page-id-XX'.
+	if ( 'edit' == $screen->parent_base ) {
+
+		// Custom post types always use 'post', so we only need to handle pages.
+		$post_type = ( 'page' == $post->post_type ) ? 'page' : 'post';
+
+		$init_array['body_class'] .= sprintf( ' %s-id-%s',
+			$post_type,
+			$post->ID
+		);
+	}
+
+	return $init_array;
+}
+
 add_action( 'tgmpa_register', 'trestle_register_required_plugins' );
 /**
  * Loads required & recommended plugins.

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -99,7 +99,7 @@ add_filter( 'tiny_mce_before_init', 'trestle_tiny_mce_before_init' );
 /**
  * Add custom classes to the body of TinyMCE previews.
  *
- * @since  2.1.0
+ * @since  2.2.0
  */
 function trestle_tiny_mce_before_init( $init_array ) {
 


### PR DESCRIPTION
This allows us to take advantage of any page or post-specific styling that we've got in the main stylesheet. It won't happen 100% automatically because none of the wrapper classes like .entry-content are used in the TinyMCE preview, but we can still get the styling into the preview by writing CSS rules like this:

.page-id-33 .entry-content h2,
.mce-content-body.page-id-33 h2 {
    color: red;
}