### PR TITLE
Move BFAL require to allow plugin's copy of the BFAL class to load first

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -30,9 +30,6 @@ require_once dirname( __FILE__ ) . '/includes/widget-areas/widget-areas.php';
 // Plugin activation class.
 require_once dirname( __FILE__ ) . '/lib/class-tgm-plugin-activation.php';
 
-// Better Font Awesome Library.
-require_once dirname( __FILE__ ) . '/lib/better-font-awesome-library/better-font-awesome-library.php';
-
 // Dev utility functions.
 require_once dirname( __FILE__ ) . '/includes/utilities/utilities.php';
 

--- a/includes/functions/theme-functions.php
+++ b/includes/functions/theme-functions.php
@@ -55,6 +55,9 @@ add_action( 'init', 'trestle_load_bfa' );
  */
 function trestle_load_bfa() {
 
+	// Better Font Awesome Library
+	require_once get_stylesheet_directory() . '/lib/better-font-awesome-library/better-font-awesome-library.php';
+
 	// Set the library initialization args.
 	$args = array(
 			'version'             => 'latest',

--- a/includes/functions/theme-functions.php
+++ b/includes/functions/theme-functions.php
@@ -56,7 +56,7 @@ add_action( 'init', 'trestle_load_bfa' );
 function trestle_load_bfa() {
 
 	// Better Font Awesome Library
-	require_once get_stylesheet_directory() . '/lib/better-font-awesome-library/better-font-awesome-library.php';
+	require_once trailingslashit( get_stylesheet_directory() ) . 'lib/better-font-awesome-library/better-font-awesome-library.php';
 
 	// Set the library initialization args.
 	$args = array(


### PR DESCRIPTION
This prevents a situation where the BFAL class is defined in Trestle but the instance is created from the BFA plugin. With this the BFAL class will get first defined by the BFA plugin and the instance will be created by the plugin. Without the plugin Trestle's copy of the class will be used.