### PR TITLE
Add support for retina logos

### DIFF
--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -19,8 +19,8 @@ function trestle_settings_defaults() {
 	// Trestle default key/value pairs.
 	$trestle_defaults = array(
 		'layout'				=> 'solid',
-		'logo_url'				=> '',
-		'logo_url_mobile'		=> '',
+		'logo_id'				=> '',
+		'logo_id_mobile'		=> '',
 		'favicon_url'			=> '',
 		'nav_primary_location'	=> 'full',
 		'mobile_nav_toggle'		=> 'small-icon',

--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -211,6 +211,12 @@ function trestle_register_required_plugins() {
 		),
 
 		array(
+			'name' 		=> 'RICG Responsive Images',
+			'slug' 		=> 'ricg-responsive-images',
+			'required' 	=> false,
+		),
+
+		array(
 			'name' 		=> 'Widget Context',
 			'slug' 		=> 'widget-context',
 			'required' 	=> false,

--- a/includes/admin/customizer.php
+++ b/includes/admin/customizer.php
@@ -55,44 +55,44 @@ function trestle_customizer_controls( $wp_customize ) {
 
 	// Upload a logo.
 	$wp_customize->add_setting(
-		'trestle-settings[logo_url]',
+		'trestle-settings[logo_id]',
 		array(
-			'default'     		=> trestle_get_option( 'logo_url' ),
+			'default'     		=> trestle_get_option( 'logo_id' ),
 			'type'        		=> 'option',
 			'capability'		=> 'edit_theme_options',
-			'sanitize_callback'	=> 'esc_url_raw',
+			'sanitize_callback'	=> 'absint',
 		)
 	);
 	$wp_customize->add_control(
-		new WP_Customize_Image_Control(
+		new WP_Customize_Media_Control(
 			$wp_customize,
 			'trestle_logo_control',
 			array(
 				'label'      => __( 'Upload a logo', 'trestle' ),
 				'section'    => 'trestle_settings_section',
-				'settings'   => 'trestle-settings[logo_url]',
+				'settings'   => 'trestle-settings[logo_id]',
 			)
 		)
 	);
 
 	// Upload a mobile logo.
 	$wp_customize->add_setting(
-		'trestle-settings[logo_url_mobile]',
+		'trestle-settings[logo_id_mobile]',
 		array(
-			'default'     		=> trestle_get_option( 'logo_url_mobile' ),
+			'default'     		=> trestle_get_option( 'logo_id_mobile' ),
 			'type'        		=> 'option',
 			'capability'		=> 'edit_theme_options',
-			'sanitize_callback'	=> 'esc_url_raw',
+			'sanitize_callback'	=> 'absint',
 		)
 	);
 	$wp_customize->add_control(
-		new WP_Customize_Image_Control(
+		new WP_Customize_Media_Control(
 			$wp_customize,
 			'trestle_mobile_logo_control',
 			array(
 			   'label'      => __( 'Upload a mobile logo', 'trestle' ),
 			   'section'    => 'trestle_settings_section',
-			   'settings'   => 'trestle-settings[logo_url_mobile]',
+			   'settings'   => 'trestle-settings[logo_id_mobile]',
 			)
 		)
 	);

--- a/includes/admin/customizer.php
+++ b/includes/admin/customizer.php
@@ -25,8 +25,8 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_section(
 		'trestle_settings_section',
 		array(
-			'title' 	=> __( 'Trestle Settings', 'trestle' ),
-			'priority'  => 160,
+			'title'    => __( 'Trestle Settings', 'trestle' ),
+			'priority' => 160,
 		)
 	);
 
@@ -34,21 +34,21 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[layout]',
 		array(
-			'default'			=> trestle_get_option( 'layout' ),
-			'type'				=> 'option',
-			'capability'		=> 'edit_theme_options',
+			'default'    => trestle_get_option( 'layout' ),
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
 		'trestle_layout_control',
 		array(
-			'section'   => 'trestle_settings_section',
-			'settings'  => 'trestle-settings[layout]',
-			'label'     => __( 'Layout', 'trestle' ),
-			'type'      => 'radio',
-			'choices'   => array(
-				'bubble'  => __( 'Bubble', 'trestle' ),
-				'solid'   => __( 'Solid', 'trestle' ),
+			'section'  => 'trestle_settings_section',
+			'settings' => 'trestle-settings[layout]',
+			'label'    => __( 'Layout', 'trestle' ),
+			'type'     => 'radio',
+			'choices'  => array(
+				'bubble' => __( 'Bubble', 'trestle' ),
+				'solid'  => __( 'Solid', 'trestle' ),
 			)
 		)
 	);
@@ -57,10 +57,10 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[logo_id]',
 		array(
-			'default'     		=> trestle_get_option( 'logo_id' ),
-			'type'        		=> 'option',
-			'capability'		=> 'edit_theme_options',
-			'sanitize_callback'	=> 'absint',
+			'default'           => trestle_get_option( 'logo_id' ),
+			'type'              => 'option',
+			'capability'        => 'edit_theme_options',
+			'sanitize_callback' => 'absint',
 		)
 	);
 	$wp_customize->add_control(
@@ -68,9 +68,10 @@ function trestle_customizer_controls( $wp_customize ) {
 			$wp_customize,
 			'trestle_logo_control',
 			array(
-				'label'      => __( 'Upload a logo', 'trestle' ),
-				'section'    => 'trestle_settings_section',
-				'settings'   => 'trestle-settings[logo_id]',
+				'label'     => __( 'Upload a logo', 'trestle' ),
+				'section'   => 'trestle_settings_section',
+				'settings'  => 'trestle-settings[logo_id]',
+				'mime_type' => 'image',
 			)
 		)
 	);
@@ -79,10 +80,10 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[logo_id_mobile]',
 		array(
-			'default'     		=> trestle_get_option( 'logo_id_mobile' ),
-			'type'        		=> 'option',
-			'capability'		=> 'edit_theme_options',
-			'sanitize_callback'	=> 'absint',
+			'default'           => trestle_get_option( 'logo_id_mobile' ),
+			'type'              => 'option',
+			'capability'        => 'edit_theme_options',
+			'sanitize_callback' => 'absint',
 		)
 	);
 	$wp_customize->add_control(
@@ -90,9 +91,10 @@ function trestle_customizer_controls( $wp_customize ) {
 			$wp_customize,
 			'trestle_mobile_logo_control',
 			array(
-			   'label'      => __( 'Upload a mobile logo', 'trestle' ),
-			   'section'    => 'trestle_settings_section',
-			   'settings'   => 'trestle-settings[logo_id_mobile]',
+				'label'      => __( 'Upload a mobile logo', 'trestle' ),
+				'section'    => 'trestle_settings_section',
+				'settings'   => 'trestle-settings[logo_id_mobile]',
+				'mime_type'  => 'image',
 			)
 		)
 	);
@@ -101,10 +103,10 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[favicon_url]',
 		array(
-			'default'     		=> trestle_get_option( 'favicon_url' ),
-			'type'        		=> 'option',
-			'capability'		=> 'edit_theme_options',
-			'sanitize_callback'	=> 'esc_url_raw',
+			'default'           => trestle_get_option( 'favicon_url' ),
+			'type'              => 'option',
+			'capability'        => 'edit_theme_options',
+			'sanitize_callback' => 'esc_url_raw',
 		)
 	);
 	$wp_customize->add_control(
@@ -112,9 +114,9 @@ function trestle_customizer_controls( $wp_customize ) {
 			$wp_customize,
 			'trestle_favicon_control',
 			array(
-			   'label'      => __( 'Upload a favicon', 'trestle' ),
-			   'section'    => 'trestle_settings_section',
-			   'settings'   => 'trestle-settings[favicon_url]',
+				'label'    => __( 'Upload a favicon', 'trestle' ),
+				'section'  => 'trestle_settings_section',
+				'settings' => 'trestle-settings[favicon_url]',
 			)
 		)
 	);
@@ -123,21 +125,21 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[nav_primary_location]',
 		array(
-			'default'			=> trestle_get_option( 'nav_primary_location' ),
-			'type'				=> 'option',
-			'capability'		=> 'edit_theme_options',
+			'default'    => trestle_get_option( 'nav_primary_location' ),
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
 		'trestle_nav_primary_location_control',
 		array(
-			'section'   => 'trestle_settings_section',
-			'settings'  => 'trestle-settings[nav_primary_location]',
-			'label'     => __( 'Menu style', 'trestle' ),
-			'type'      => 'select',
-			'choices'   => array(
-				'full'  	=> __( 'Full Width', 'trestle' ),
-				'header'   	=> __( 'Header Right', 'trestle' ),
+			'section'  => 'trestle_settings_section',
+			'settings' => 'trestle-settings[nav_primary_location]',
+			'label'    => __( 'Menu style', 'trestle' ),
+			'type'     => 'select',
+			'choices'  => array(
+				'full'   => __( 'Full Width', 'trestle' ),
+				'header' => __( 'Header Right', 'trestle' ),
 			)
 		)
 	);
@@ -146,9 +148,9 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[mobile_nav_toggle]',
 		array(
-			'default'			=> trestle_get_option( 'mobile_nav_toggle' ),
-			'type'				=> 'option',
-			'capability'		=> 'edit_theme_options',
+			'default'    => trestle_get_option( 'mobile_nav_toggle' ),
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
@@ -159,8 +161,8 @@ function trestle_customizer_controls( $wp_customize ) {
 			'label'     => __( 'Mobile Menu Toggle', 'trestle' ),
 			'type'      => 'select',
 			'choices'   => array(
-				'small-icon'  	=> __( 'Small Icon', 'trestle' ),
-				'big-button'   	=> __( 'Big Button', 'trestle' ),
+				'small-icon'    => __( 'Small Icon', 'trestle' ),
+				'big-button'    => __( 'Big Button', 'trestle' ),
 			)
 		)
 	);
@@ -169,9 +171,9 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[search_in_nav]',
 		array(
-			'default'			=> trestle_get_option( 'search_in_nav' ),
-			'type'				=> 'option',
-			'capability'		=> 'edit_theme_options',
+			'default'    => trestle_get_option( 'search_in_nav' ),
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
@@ -180,7 +182,7 @@ function trestle_customizer_controls( $wp_customize ) {
 			'section'   => 'trestle_settings_section',
 			'settings'  => 'trestle-settings[search_in_nav]',
 			'label'     => __( 'Add search to mobile navigation', 'trestle' ),
-			'type'		=> 'checkbox',
+			'type'      => 'checkbox',
 		)
 	);
 
@@ -188,18 +190,18 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[read_more_text]',
 		array(
-			'default'			=> trestle_get_option( 'read_more_text' ),
-			'type'				=> 'option',
-			'capability'     	=> 'edit_theme_options',
-			'sanitize_callback'	=> 'wp_kses_post',
+			'default'           => trestle_get_option( 'read_more_text' ),
+			'type'              => 'option',
+			'capability'        => 'edit_theme_options',
+			'sanitize_callback' => 'wp_kses_post',
 		)
 	);
 	$wp_customize->add_control(
 		'trestle_read_more_text_control',
 		array(
-			'section'   => 'trestle_settings_section',
-			'settings'  => 'trestle-settings[read_more_text]',
-			'label'     => __( 'Custom read more link text', 'trestle' ),
+			'section'  => 'trestle_settings_section',
+			'settings' => 'trestle-settings[read_more_text]',
+			'label'    => __( 'Custom read more link text', 'trestle' ),
 		)
 	);
 
@@ -207,31 +209,32 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[revisions_number]',
 		array(
-			'default'			=> trestle_get_option( 'revisions_number' ),
-			'type'				=> 'option',
-			'capability'		=> 'edit_theme_options',
+			'default'    => trestle_get_option( 'revisions_number' ),
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
+			'sanitize_callback' => 'absint',
 		)
 	);
 	$wp_customize->add_control(
 		'trestle_revisions_number_control',
 		array(
-			'section'   => 'trestle_settings_section',
-			'settings'  => 'trestle-settings[revisions_number]',
-			'label'     => __( 'Number of post revisions', 'trestle' ),
-			'type'      => 'select',
-			'choices'   => array(
-				'-1'    => __( 'Unlimited', 'trestle' ),
-				'0'  	=> '0',
-				'1' 	=> '1',
-				'2'		=> '2',
-				'3'		=> '3',
-				'4'		=> '4',
-				'5' 	=> '5',
-				'6'		=> '6',
-				'7' 	=> '7',
-				'8' 	=> '8',
-				'9' 	=> '9',
-				'10' 	=> '10',
+			'section'  => 'trestle_settings_section',
+			'settings' => 'trestle-settings[revisions_number]',
+			'label'    => __( 'Number of post revisions', 'trestle' ),
+			'type'     => 'select',
+			'choices'  => array(
+				'-1' => __( 'Unlimited', 'trestle' ),
+				'0'  => '0',
+				'1'  => '1',
+				'2'  => '2',
+				'3'  => '3',
+				'4'  => '4',
+				'5'  => '5',
+				'6'  => '6',
+				'7'  => '7',
+				'8'  => '8',
+				'9'  => '9',
+				'10' => '10',
 			)
 		)
 	);
@@ -240,26 +243,26 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[footer_widgets_number]',
 		array(
-			'default'			=> trestle_get_option( 'footer_widgets_number' ),
-			'type'				=> 'option',
-			'capability' 		=> 'edit_theme_options',
+			'default'    => trestle_get_option( 'footer_widgets_number' ),
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
 		'trestle_footer_widgets_number_control',
 		array(
-			'section'   => 'trestle_settings_section',
-			'settings'  => 'trestle-settings[footer_widgets_number]',
-			'label'     => __( 'Number of footer widgets', 'trestle' ),
-			'type'      => 'select',
-			'choices'   => array(
-				'0'  	=> '0',
-				'1' 	=> '1',
-				'2'		=> '2',
-				'3'		=> '3',
-				'4'		=> '4',
-				'5' 	=> '5',
-				'6'		=> '6',
+			'section'  => 'trestle_settings_section',
+			'settings' => 'trestle-settings[footer_widgets_number]',
+			'label'    => __( 'Number of footer widgets', 'trestle' ),
+			'type'     => 'select',
+			'choices'  => array(
+				'0' => '0',
+				'1' => '1',
+				'2'	=> '2',
+				'3'	=> '3',
+				'4'	=> '4',
+				'5' => '5',
+				'6'	=> '6',
 			)
 		)
 	);
@@ -268,17 +271,17 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[link_icons_title]',
 		array(
-			'default'			=> '',
-			'type'				=> 'option',
+			'default' => '',
+			'type'    => 'option',
 		)
 	);
 	$wp_customize->add_control(
 		'trestle_link_icons_title',
 		array(
-			'section'	=> 'trestle_settings_section',
-			'settings'	=> 'trestle-settings[link_icons_title]',
-			'label'		=> __( 'Icon links', 'trestle' ),
-			'type'		=> 'hidden',
+			'section'  => 'trestle_settings_section',
+			'settings' => 'trestle-settings[link_icons_title]',
+			'label'    => __( 'Icon links', 'trestle' ),
+			'type'     => 'hidden',
 		)
 	);
 
@@ -286,18 +289,18 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[external_link_icons]',
 		array(
-			'default'			=> trestle_get_option( 'external_link_icons' ),
-			'type'				=> 'option',
-			'capability'		=> 'edit_theme_options',
+			'default'    => trestle_get_option( 'external_link_icons' ),
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
 		'trestle_external_link_icons',
 		array(
-			'section'	=> 'trestle_settings_section',
-			'settings'	=> 'trestle-settings[external_link_icons]',
-			'label'		=> __( 'Add icons to external links', 'trestle' ),
-			'type'		=> 'checkbox',
+			'section'  => 'trestle_settings_section',
+			'settings' => 'trestle-settings[external_link_icons]',
+			'label'    => __( 'Add icons to external links', 'trestle' ),
+			'type'     => 'checkbox',
 		)
 	);
 
@@ -305,18 +308,18 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[email_link_icons]',
 		array(
-			'default'			=> trestle_get_option( 'email_link_icons' ),
-			'type'				=> 'option',
-			'capability'		=> 'edit_theme_options',
+			'default'    => trestle_get_option( 'email_link_icons' ),
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
 		'trestle_email_link_icons',
 		array(
-			'section'	=> 'trestle_settings_section',
-			'settings'	=> 'trestle-settings[email_link_icons]',
-			'label'		=> __( 'Add icons to email links', 'trestle' ),
-			'type'		=> 'checkbox',
+			'section'  => 'trestle_settings_section',
+			'settings' => 'trestle-settings[email_link_icons]',
+			'label'    => __( 'Add icons to email links', 'trestle' ),
+			'type'     => 'checkbox',
 		)
 	);
 
@@ -324,18 +327,18 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[pdf_link_icons]',
 		array(
-			'default'			=> trestle_get_option( 'pdf_link_icons' ),
-			'type'				=> 'option',
-			'capability'		=> 'edit_theme_options',
+			'default'    => trestle_get_option( 'pdf_link_icons' ),
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
 		'trestle_pdf_link_icons',
 		array(
-			'section'	=> 'trestle_settings_section',
-			'settings'	=> 'trestle-settings[pdf_link_icons]',
-			'label'		=> __( 'Add icons to .pdf links', 'trestle' ),
-			'type'		=> 'checkbox',
+			'section'  => 'trestle_settings_section',
+			'settings' => 'trestle-settings[pdf_link_icons]',
+			'label'    => __( 'Add icons to .pdf links', 'trestle' ),
+			'type'     => 'checkbox',
 		)
 	);
 
@@ -343,18 +346,18 @@ function trestle_customizer_controls( $wp_customize ) {
 	$wp_customize->add_setting(
 		'trestle-settings[doc_link_icons]',
 		array(
-			'default'			=> trestle_get_option( 'doc_link_icons' ),
-			'type'				=> 'option',
-			'capability' 		=> 'edit_theme_options',
+			'default'    => trestle_get_option( 'doc_link_icons' ),
+			'type'       => 'option',
+			'capability' => 'edit_theme_options',
 		)
 	);
 	$wp_customize->add_control(
 		'trestle_doc_link_icons',
 		array(
-			'section'	=> 'trestle_settings_section',
-			'settings'	=> 'trestle-settings[doc_link_icons]',
-			'label'		=> __( 'Add icons to .doc links', 'trestle' ),
-			'type'		=> 'checkbox',
+			'section'  => 'trestle_settings_section',
+			'settings' => 'trestle-settings[doc_link_icons]',
+			'label'    => __( 'Add icons to .doc links', 'trestle' ),
+			'type'     => 'checkbox',
 		)
 	);
 

--- a/includes/functions/theme-functions.php
+++ b/includes/functions/theme-functions.php
@@ -216,42 +216,55 @@ add_filter( 'genesis_seo_title', 'trestle_do_logos', 10, 3 );
  */
 function trestle_do_logos( $title, $inside, $wrap ) {
 
-	$logo_url = trestle_get_option( 'logo_url' );
-	$logo_url_mobile = trestle_get_option( 'logo_url_mobile' );
+	$logo_id = trestle_get_option( 'logo_id' );
+	$logo_id_mobile = trestle_get_option( 'logo_id_mobile' );
 	$logo_html = '';
 
 	// Regular logo.
-	if ( $logo_url ) {
+	if ( $logo_id ) {
 
-		// Default logo class.
-		$classes = array('logo-full');
+		// Default logo classes.
+		$classes = array(
+			'logo',
+			'logo-full'
+		);
 
 		// If no mobile logo is specified, make regular logo act as mobile logo too.
-		if( ! $logo_url_mobile )
+		if( ! $logo_id_mobile ) {
 			$classes[] = 'show';
+		}
 
-		$logo_html .= sprintf( '<img class="logo %s" alt="%s" src="%s" />',
-			implode(' ', $classes),
-			esc_attr( get_bloginfo( 'name' ) ),
-			$logo_url
+		// Prepare the classes.
+		$logo_attr = array(
+			'class'	=> implode( $classes, ' ' ),
 		);
+
+		// Build the <img> tag.
+		$logo_html .= wp_get_attachment_image( $logo_id, 'full', false, $logo_attr );
+
 	}
 
 	// Mobile logo.
-	if ( $logo_url_mobile ) {
+	if ( $logo_id_mobile ) {
 
 		// Default mobile logo class.
-		$classes = array('logo-mobile');
+		$classes = array(
+			'logo',
+			'logo-mobile'
+		);
 
 		// If no regular logo is specified, make mobile logo act as regular logo too.
-		if( ! $logo_url )
+		if( ! $logo_id )
 			$classes[] = 'show';
 
-		$logo_html .= sprintf( '<img class="logo %s" alt="%s" src="%s" />',
-			implode(' ', $classes),
-			esc_attr( get_bloginfo( 'name' ) ),
-			$logo_url_mobile
+		// Prepare the classes.
+		$logo_attr = array(
+			'class'	=> implode( $classes, ' ' ),
 		);
+
+		// Build the <img> tag.
+		$logo_html .= wp_get_attachment_image( $logo_id_mobile, 'full', false, $logo_attr );
+
 	}
 
 	if ( $logo_html ) {


### PR DESCRIPTION
These changes make the switch to storing the logos by their attachment IDs and outputting them using wp_get_attachment_image. I've tested everything thoroughly and confirmed that when RICG is active the logo img tags get the proper extra attributes for retina support. I've kept all the same classes on the logos so that behavior with regards to the mobile vs. normal logo is exactly as before.

I didn't touch the favicon because I figured storing that by URL makes more sense, but I'm sure there's something to be said for serving responsive favicons also. These are usually output with additional favicon tags rather than as an attribute on the main favicon tag, and they are used for example when a user on a smartphone bookmarks a website to their home screen. We can add support for that when the time is right.

Also, I didn't include a function to convert any existing logos to be stored in the new way, so this will be a breaking but easily repaired change on all existing Trestle sites. I'm open to adding that before we merge if we think we'll want it.

Finally, I added the RICG Responsive Images plugin to our recommended plugins list.