### PR TITLE
Remove My Page Order plugin from required plugins list.

### DIFF
--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -187,12 +187,6 @@ function trestle_register_required_plugins() {
 		),
 
 		array(
-			'name' 		=> 'My Page Order',
-			'slug' 		=> 'my-page-order',
-			'required' 	=> false,
-		),
-
-		array(
 			'name' 		=> 'Post Thumbnail Editor',
 			'slug' 		=> 'post-thumbnail-editor',
 			'required' 	=> false,


### PR DESCRIPTION
Plugin is no longer supported. Fixes #41 