### PR TITLE
Fix/beaver builder

### DIFF
--- a/includes/admin/admin.php
+++ b/includes/admin/admin.php
@@ -105,10 +105,7 @@ function trestle_tiny_mce_before_init( $init_array ) {
 
 	global $post;
 
-	$screen = get_current_screen();
-
-	// If we're on an edit screen, add an appropriate 'post-id-XX' or 'page-id-XX'.
-	if ( is_object( $screen ) && 'edit' == $screen->parent_base ) {
+	if ( $post ) {
 
 		// Custom post types always use 'post', so we only need to handle pages.
 		$post_type = ( 'page' == $post->post_type ) ? 'page' : 'post';
@@ -117,6 +114,7 @@ function trestle_tiny_mce_before_init( $init_array ) {
 			$post_type,
 			$post->ID
 		);
+
 	}
 
 	return $init_array;


### PR DESCRIPTION
Fixes #44 

Previously, the trestle_tiny_mce_before_init filter was causing a fatal
error when it was trying to call get_current_screen() on the front-end,
which isn't availably unless /wp-admin/includes/screen.php is included,
which it isn't on the front end. This patch switches from checking the
current screen to simply checking if the post object exists. Not sure if
there are any edge cases where the current screen check does something
the post check doesn't - I'll leave that to you @braad to decide as I
think you added this code.