### PR TITLE
Accessibility updates

### DIFF
--- a/includes/functions/theme-functions.php
+++ b/includes/functions/theme-functions.php
@@ -29,6 +29,9 @@ function trestle_add_theme_support() {
 	// Add support for footer widgets if specified in Trestle settings.
 	add_theme_support( 'genesis-footer-widgets', trestle_get_option( 'footer_widgets_number' ) );
 
+	//* Add Accessibility support
+	add_theme_support( 'genesis-accessibility', array( 'headings', 'drop-down-menu',  'search-form', 'skip-links', 'rems' ) );
+
 }
 
 add_action( 'after_setup_theme', 'trestle_remove_genesis_css_enqueue' );

--- a/style.css
+++ b/style.css
@@ -25,6 +25,8 @@
 		- Forms & Buttons
 		- Tables
 		- Screen Reader Text
+		- Skip Links
+		- Accessible Menu
 	- Structure and Layout
 		- Site Containers
 		- Bubble Layout
@@ -642,7 +644,7 @@ td {
 	padding: 0.6rem 0;
 }
 
-/* ## Screen reader text
+/* Screen reader text
 --------------------------------------------- */
 
 .screen-reader-text,
@@ -678,7 +680,7 @@ td {
     position: relative;
 }
 
-/* # Skip Links
+/* Skip Links
 ---------------------------------------------------------------------------------------------------- */
 .genesis-skip-link li {
 	height: 0;
@@ -686,7 +688,7 @@ td {
 	list-style: none;
 }
 
-/* ## Accessible Menu
+/* Accessible Menu
 --------------------------------------------- */
 
 .menu .menu-item:focus {

--- a/style.css
+++ b/style.css
@@ -24,6 +24,7 @@
 		- Objects
 		- Forms & Buttons
 		- Tables
+		- Screen Reader Text
 	- Structure and Layout
 		- Site Containers
 		- Bubble Layout
@@ -639,6 +640,81 @@ td {
 	border-top: 1px solid #ddd;
 	padding: 6px 0;
 	padding: 0.6rem 0;
+}
+
+/* ## Screen reader text
+--------------------------------------------- */
+
+.screen-reader-text,
+.screen-reader-text span,
+.screen-reader-shortcut {
+	position: absolute !important;
+	clip: rect(0, 0, 0, 0);
+	height: 1px;
+	width: 1px;
+	border: 0;
+	overflow: hidden;
+	color: #333;
+	background: #fff;
+}
+
+.screen-reader-text:focus,
+.screen-reader-shortcut:focus,
+.genesis-nav-menu .search input[type="submit"]:focus,
+.widget_search input[type="submit"]:focus  {
+	clip: auto !important;
+	height: auto;
+	width: auto;
+	display: block;
+	font-size: 1em;
+	font-weight: bold;
+	padding: 15px 23px 14px;
+	z-index: 100000; /* Above WP toolbar. */
+	text-decoration: none;
+	box-shadow: 0 0 2px 2px rgba(0,0,0,.6);
+}
+
+.more-link {
+    position: relative;
+}
+
+/* # Skip Links
+---------------------------------------------------------------------------------------------------- */
+.genesis-skip-link li {
+	height: 0;
+	width: 0;
+	list-style: none;
+}
+
+/* ## Accessible Menu
+--------------------------------------------- */
+
+.menu .menu-item:focus {
+	position: static;
+}
+
+.menu .menu-item > a:focus + ul.sub-menu,
+.menu .menu-item.sfHover > ul.sub-menu {
+	left: auto;
+	opacity: 1;
+}
+
+/* hide sub-menus */
+ul.sub-menu,
+.genesis-nav-menu [class*="current-"] > ul.sub-menu.open,
+.genesis-nav-menu [class*="current_"] > ul.sub-menu.open {
+	display: none !important;
+}
+
+.genesis-nav-menu ul.sub-menu.open,
+.genesis-nav-menu ul.sub-menu.open {
+	display: block !important;
+}
+
+
+/* hide arrow indicators */
+span.sf-sub-indicator {
+   display: none;
 }
 
 /*
@@ -2210,6 +2286,13 @@ Media Queries
 	.wrap {
 		padding-left: 0;
 		padding-right: 0;
+	}
+
+	/* show sub-menus */
+	ul.sub-menu,
+	.genesis-nav-menu ul.sub-menu.open,
+	.genesis-nav-menu ul.sub-menu.open {
+	   display: block !important;
 	}
 
 	/* Header


### PR DESCRIPTION
I wanted to add this new accessibility theme support to trestle. These updates include keyboard navigation and improved labels on page elements. The keyboard nav uses JS on hover to open the sub menu nav items. I noticed there were some issues with the Trestle mobile nav toggle when this new accessibility JS was active, so I wrote some CSS to negate these issues. 