### PR TITLE
Include js to remove accessibility menu functionality on mobile.

### DIFF
--- a/includes/js/theme-jquery.js
+++ b/includes/js/theme-jquery.js
@@ -149,6 +149,11 @@ jQuery( document ).ready( function( $ ) {
 		$button.toggleClass( 'open' ).next( '.widget-area' ).slideToggle();
 	});
 
+	//Remove accessibility menu toggle on mobile.
+	if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
+	 	$( '#menu-main-menu').superfish( 'destroy' );
+	}
+
 	// Executes when complete page is fully loaded, including all frames, objects, and images.
 	$( window ).on( 'load', function() {
 


### PR DESCRIPTION
Our new keyboard navigation accessibility enhancements were causing some issues with the mobile menu drop downs. Because keyboard navigation isn't a factor on mobile, we can remove this functionality there. 